### PR TITLE
Support to limit number of backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,25 @@ AWS_ACCESS_KEY_ID=<key_here>
 AWS_SECRET_ACCESS_KEY=<secret_here>
 AWS_DEFAULT_REGION=us-east-1
 BACKUP_NAME=mysql
+MAX_NUMBER_OF_BACKUPS=10
 PATHS_TO_BACKUP=/etc/mysql /var/lib/mysql
-S3_BUCKET_NAME=docker-backups.example.com
+S3_BUCKET_NAME=my-bucket
 CRON_TIME=3 0-23/3 * * *
 ```
 
 `dockup` will use your AWS credentials to create a new bucket with name as per the environment variable `S3_BUCKET_NAME`, or if not defined, using the default name `docker-backups.example.com`. The paths in `PATHS_TO_BACKUP` will be tarballed, gzipped, time-stamped and uploaded to the S3 bucket regularly. You can control the time when it will starts with `CRON_TIME`.
 
-Then, you will be able to see the backups at AWS Management Console.
+Then, you will be able to see the backups are on S3 with `aws s3 ls` command.
 
-![](http://s.tutum.co.s3.amazonaws.com/support/images/dockup-readme.png)
+```bash
+$ aws s3 ls s3://my-bucket/mysql/
+2016-02-05 04:02:54    5190945 mysql.2016-02-05-04-02-51.tar.gz
+2016-02-05 04:03:08    5190945 mysql.2016-02-05-04-03-05.tar.gz
+2016-02-05 04:05:34    5190945 mysql.2016-02-05-04-05-31.tar.gz
+2016-02-05 04:07:06    5190945 mysql.2016-02-05-04-07-03.tar.gz
+2016-02-05 04:07:31    5190945 mysql.2016-02-05-04-07-28.tar.gz
+```
+
 
 ### Restore
 To perform a restore launch the container with the RESTORE variable set to `true`.
@@ -77,8 +86,9 @@ AWS_ACCESS_KEY_ID=<key_here>
 AWS_SECRET_ACCESS_KEY=<secret_here>
 AWS_DEFAULT_REGION=us-east-1
 BACKUP_NAME=mysql
+MAX_NUMBER_OF_BACKUPS=10
 PATHS_TO_BACKUP=/etc/mysql /var/lib/mysql
-S3_BUCKET_NAME=docker-backups.example.com
+S3_BUCKET_NAME=my-bucket
 RESTORE=true
 ```
 

--- a/backup.sh
+++ b/backup.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+echo "=> Backup has been started"
+
 # Get timestamp
 : ${BACKUP_SUFFIX:=.$(date +"%Y-%m-%d-%H-%M-%S")}
 readonly tarball=$BACKUP_NAME$BACKUP_SUFFIX.tar.gz
 
 # Create a gzip compressed tarball with the volume(s)
+echo "=> Creating compressed backup: $tarball"
 tar czf $tarball $BACKUP_TAR_OPTION $PATHS_TO_BACKUP
 
 # Create bucket, if it doesn't already exist
@@ -15,4 +18,24 @@ then
 fi
 
 # Upload the backup to S3 with timestamp
-aws s3 --region $AWS_DEFAULT_REGION cp $tarball s3://$S3_BUCKET_NAME/$tarball
+echo "=> Uploading the backup to S3: $tarball"
+aws s3 --region $AWS_DEFAULT_REGION cp $tarball s3://$S3_BUCKET_NAME/$BACKUP_NAME/$tarball
+
+# Dispose of old backups
+if [[ -n "$MAX_NUMBER_OF_BACKUPS" ]]; then
+  if [[ "$MAX_NUMBER_OF_BACKUPS" -gt 0 ]]; then
+    backups=$(aws s3 ls s3://$S3_BUCKET_NAME/$BACKUP_NAME/ \
+      | awk -F " " '{print $4}' \
+      | grep ^$BACKUP_NAME \
+      |  head -n -${MAX_NUMBER_OF_BACKUPS}
+    )
+
+    for backup in $backups
+    do
+      echo "=> Removing an old backup: s3://$S3_BUCKET_NAME/$BACKUP_NAME/$backup"
+      aws s3 rm s3://$S3_BUCKET_NAME/$BACKUP_NAME/$backup
+    done
+  fi
+fi
+
+echo "=> Backup has been completed"

--- a/restore.sh
+++ b/restore.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+echo "=> Restore has been started"
+
 # Find last backup file
-: ${LAST_BACKUP:=$(aws s3 ls s3://$S3_BUCKET_NAME | awk -F " " '{print $4}' | grep ^$BACKUP_NAME | sort -r | head -n1)}
+: ${LAST_BACKUP:=$(aws s3 ls s3://$S3_BUCKET_NAME/$BACKUP_NAME/ | awk -F " " '{print $4}' | grep ^$BACKUP_NAME | sort -r | head -n1)}
 
 # Stop to restore, if backup doesn't exist
 if [ "$LAST_BACKUP" = "" ] ;
@@ -11,7 +13,16 @@ then
 fi
 
 # Download backup from S3
-aws s3 cp s3://$S3_BUCKET_NAME/$LAST_BACKUP $LAST_BACKUP
+echo "=> Downloading latest backup from S3: $LAST_BACKUP"
+aws s3 cp s3://$S3_BUCKET_NAME/$BACKUP_NAME/$LAST_BACKUP $LAST_BACKUP
 
 # Extract backup
+echo "=> Extracting the backup: $LAST_BACKUP"
 tar xzf $LAST_BACKUP $RESTORE_TAR_OPTION
+for path in $PATHS_TO_BACKUP
+do
+  echo "=> Extracted contents: $path"
+  ls -l $path
+done
+
+echo "=> Restore has been completed"


### PR DESCRIPTION
## WHAT

Enable to limit number of backups with `MAX_NUMBER_OF_BACKUPS`
If `MAX_NUMBER_OF_BACKUPS` is empty, dockup doesn't remove old backups.
## WHY

I don't need too old backup.
